### PR TITLE
Use Etc.getpwuid instead of getlogin

### DIFF
--- a/lib/kitchen/driver/openstack.rb
+++ b/lib/kitchen/driver/openstack.rb
@@ -261,7 +261,7 @@ module Kitchen
       def default_name
         [
           instance.name.gsub(/\W/, "")[0..14],
-          (Etc.getlogin || "nologin").gsub(/\W/, "")[0..14],
+          (Etc.getpwuid.name || "nologin").gsub(/\W/, "")[0..14],
           Socket.gethostname.gsub(/\W/, "")[0..22],
           Array.new(7) { rand(36).to_s(36) }.join,
         ].join("-")


### PR DESCRIPTION
`Etc.getlogin` returns `nil` on my environment. `Etc.getpwuid.name` works well. From the [ruby docs](https://docs.ruby-lang.org/en/2.0.0/Etc.html), they recommend using the latter as well.